### PR TITLE
Added flow.units to the object returned by loadReg

### DIFF
--- a/R/loadReg.R
+++ b/R/loadReg.R
@@ -221,7 +221,7 @@ loadReg <- function(formula, data, subset, na.action, flow, dates,
                  flow=flow, dates=dates, Qadj=Qadj,
                  Tadj=Tadj, model.no=model.no, model.eval=MEC,
                  method=method, conc.units=conc.units, Time=Time,
-                 Sum.flow=summary(Flow),
+                 Sum.flow=summary(Flow), flow.units=flow.units,
                  load.units=load.units, PoR=PoR, xvars=xvars,
                  lfit=lfit, cfit=cfit, time.step=time.step)
   class(retval) <- "loadReg"


### PR DESCRIPTION
conc.units and load.units are already returned within the loadReg object, but flow.units are not. Including flow.units would be very helpful in (1) sharing and interpreting loadReg objects, and (2) getting the units right when comparing the results of a loadReg call to the results of other load regression and estimation methods.

The change is simple. I've tried to think of any possible problems that could arise from this change, but I see none. And I have tested the S3 methods specific to the loadReg class on objects created with flow.units elements. As far as I can tell, all of these methods still run correctly.
