### PR TITLE
tests with travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ src-x64
 .Rproj.user
 .Rhistory
 .RData
+*.Rproj
+src/*.o
+src/*.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ warnings_are_errors: true
 
 script: 
   - |
-    R CMD build .
-    travis_wait 20 R CMD check rloadest*tar.gz
+    R CMD build ${R_BUILD_ARGS} .
+    travis_wait 20 R CMD check ${R_CHECK_ARGS} rloadest*tar.gz
 
 r_github_packages:
   - jimhester/covr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Suggests:
     dataRetrieval,
     EGRET,
     survival,
-    knitr
+    knitr,
+    testthat
 BugReports: https://github.com/USGS-R/rloadest/issues
 LazyLoad: yes
 LazyData: yes

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,3 @@
+library(testthat)
+library(rloadest)
+test_check("rloadest")

--- a/tests/testthat/test-loadReg.R
+++ b/tests/testthat/test-loadReg.R
@@ -1,0 +1,8 @@
+context('loadReg')
+
+test_that("loadReg model can be created", {
+  app1.lr <- loadReg(Phosphorus ~ model(1), data = app1.calib, flow = "FLOW",
+                     dates = "DATES", conc.units="mg/L",
+                     station="Illinois River at Marseilles, Ill.")
+  expect_is(app1.lr, "loadReg")
+})


### PR DESCRIPTION
Goal: narrow in on the segfaults caused by calls to `loadReg`. These segfaults may be occurring in other packages depended on by `rloadest`, but it would be helpful to see them at this level as well.

Changes:
* added testthat and a single test that calls `loadReg`
* because current Travis is stopping at segfault somewhere within vignettes, try to modify .travis.yml so that it doesn't build vignettes