### PR TITLE
remove dist: trusty from travis build instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@
 
 language: r
 cache: packages
-dist: trusty
 
 matrix:
   include:


### PR DESCRIPTION
Get [an error](https://travis-ci.org/github/USGS-R/rloadest/jobs/731351941) on travis builds:

`dist: trusty is no longer supported for language: r`

See https://travis-ci.community/t/error-checking-r-package-trusty-is-no-longer-supported-for-language-r/9943